### PR TITLE
feat: delete workshop mutation

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -33,6 +33,10 @@ type AcceptInvitationResponse {
   ok: Boolean!
 }
 
+type DeleteWorkshopResponse {
+  ok: Boolean!
+}
+
 type Query {
   me: User!
   workshops(nextToken: String, limit: Int): WorkshopList!
@@ -45,6 +49,7 @@ type Mutation {
     workshopId: ID!
     input: CreateOrUpdateWorkshopInput!
   ): Workshop!
+  deleteWorkshop(workshopId: ID!): DeleteWorkshopResponse!
   acceptInvitation(
     inviteId: ID!
     emailAddress: String!

--- a/src/constructs/graphql-api.ts
+++ b/src/constructs/graphql-api.ts
@@ -114,6 +114,14 @@ export class GraphQLApi extends Construct {
       responseMappingTemplate: appsync.MappingTemplate.fromString(mappingTemplates.functionUpdateWorkshop.response),
     });
 
+    const deleteWorkshopFunction = new appsync.AppsyncFunction(this, 'DeleteWorkshopFunction', {
+      name: 'deleteWorkshopFunction',
+      api,
+      dataSource: workshopTableDataSource,
+      requestMappingTemplate: appsync.MappingTemplate.fromString(mappingTemplates.functionDeleteWorkshop.request),
+      responseMappingTemplate: appsync.MappingTemplate.fromString(mappingTemplates.functionDeleteWorkshop.response),
+    });
+
     const acceptInvitationFunction = new appsync.AppsyncFunction(this, 'AcceptInvitationFunction', {
       name: 'updateWorkshopFunction',
       api,
@@ -153,6 +161,15 @@ export class GraphQLApi extends Construct {
       pipelineConfig: [isAdminFunction, updateWorkshopFunction, createClerkUsersFunction],
       requestMappingTemplate: appsync.MappingTemplate.fromString(mappingTemplates.mutationUpdateWorkshop.request),
       responseMappingTemplate: appsync.MappingTemplate.fromString(mappingTemplates.mutationUpdateWorkshop.response),
+    });
+
+    new appsync.Resolver(this, 'DeleteWorkshopPipelineResolver', {
+      api,
+      typeName: 'Mutation',
+      fieldName: 'deleteWorkshop',
+      pipelineConfig: [isAdminFunction, deleteWorkshopFunction],
+      requestMappingTemplate: appsync.MappingTemplate.fromString(mappingTemplates.mutationDeleteWorkshop.request),
+      responseMappingTemplate: appsync.MappingTemplate.fromString(mappingTemplates.mutationDeleteWorkshop.response),
     });
 
     new appsync.Resolver(this, 'AcceptInvitationPipelineResolver', {

--- a/src/vtl/__snapshots__/functionDeleteWorkshop.test.ts.snap
+++ b/src/vtl/__snapshots__/functionDeleteWorkshop.test.ts.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`request mapping should match snapshot 1`] = `
+Object {
+  "key": Object {
+    "id": Object {
+      "S": "beb79a10-437e-48df-96e2-9cd87fdc063f",
+    },
+  },
+  "operation": "DeleteItem",
+  "version": "2018-05-29",
+}
+`;
+
+exports[`response mapping should match snapshot 1`] = `
+Object {
+  "any": "data",
+}
+`;

--- a/src/vtl/__snapshots__/mutationDeleteWorkshop.test.ts.snap
+++ b/src/vtl/__snapshots__/mutationDeleteWorkshop.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`request mapping should match snapshot 1`] = `Object {}`;
+
+exports[`response mapping should match snapshot 1`] = `
+Object {
+  "ok": true,
+}
+`;

--- a/src/vtl/functionDeleteWorkshop.test.ts
+++ b/src/vtl/functionDeleteWorkshop.test.ts
@@ -1,0 +1,30 @@
+import Parser from 'appsync-template-tester';
+import { request, response } from './functionDeleteWorkshop';
+
+describe('request mapping', () => {
+  it('should match snapshot', () => {
+    const parser = new Parser(request);
+
+    const context = {
+      arguments: {
+        workshopId: 'beb79a10-437e-48df-96e2-9cd87fdc063f',
+      },
+    };
+
+    expect(parser.resolve(context)).toMatchSnapshot();
+  });
+});
+
+describe('response mapping', () => {
+  it('should match snapshot', () => {
+    const parser = new Parser(response);
+
+    const context = {
+      result: {
+        any: 'data',
+      },
+    };
+
+    expect(parser.resolve(context)).toMatchSnapshot();
+  });
+});

--- a/src/vtl/functionDeleteWorkshop.ts
+++ b/src/vtl/functionDeleteWorkshop.ts
@@ -1,0 +1,13 @@
+export const request = `
+  {
+    "version" : "2018-05-29",
+    "operation" : "DeleteItem",
+    "key": {
+      "id": $util.dynamodb.toDynamoDBJson($ctx.arguments.workshopId)
+    }
+  }
+`;
+
+export const response = `
+  $util.toJson($ctx.result)
+`;

--- a/src/vtl/index.ts
+++ b/src/vtl/index.ts
@@ -1,10 +1,12 @@
 export * as functionIsAdmin from './functionIsAdmin';
 export * as functionStoreWorkshop from './functionStoreWorkshop';
 export * as functionUpdateWorkshop from './functionUpdateWorkshop';
+export * as functionDeleteWorkshop from './functionDeleteWorkshop';
 export * as functionCreateClerkUsers from './functionCreateClerkUsers';
 export * as functionAcceptInvitation from './functionAcceptInvitation';
 export * as mutationCreateWorkshop from './mutationCreateWorkshop';
 export * as mutationUpdateWorkshop from './mutationUpdateWorkshop';
+export * as mutationDeleteWorkshop from './mutationDeleteWorkshop';
 export * as mutationAcceptInvitation from './mutationAcceptInvitation';
 export * as queryMe from './queryMe';
 export * as queryWorkshops from './queryWorkshops';

--- a/src/vtl/mutationDeleteWorkshop.test.ts
+++ b/src/vtl/mutationDeleteWorkshop.test.ts
@@ -1,0 +1,24 @@
+import Parser from 'appsync-template-tester';
+import { request, response } from './mutationDeleteWorkshop';
+
+describe('request mapping', () => {
+  it('should match snapshot', () => {
+    const parser = new Parser(request);
+
+    expect(parser.resolve({})).toMatchSnapshot();
+  });
+});
+
+describe('response mapping', () => {
+  it('should match snapshot', () => {
+    const parser = new Parser(response);
+
+    const context = {
+      result: {
+        any: 'data',
+      },
+    };
+
+    expect(parser.resolve(context)).toMatchSnapshot();
+  });
+});

--- a/src/vtl/mutationDeleteWorkshop.ts
+++ b/src/vtl/mutationDeleteWorkshop.ts
@@ -1,0 +1,7 @@
+export const request = `
+  {}
+`;
+
+export const response = `
+  { "ok": true }
+`;


### PR DESCRIPTION
We'd like to introduce a new mutation to delete workshops. The mutation deletes the workshop entity entirely from the database.

Paired with @skomp 